### PR TITLE
Karpenter/cilium upgrade

### DIFF
--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -766,10 +766,6 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["validation.webhook.karpenter.sh", "validation.webhook.config.karpenter.sh"]
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
-    verbs: ["update"]
-    resourceNames: ["defaulting.webhook.karpenter.sh"]
 
 ---
 # Source: karpenter/templates/clusterrole.yaml
@@ -965,7 +961,7 @@ spec:
       dnsPolicy: Default
       containers:
         - name: controller
-          image: public.ecr.aws/karpenter/controller:v0.27.2
+          image: public.ecr.aws/karpenter/controller:v0.27.3
           imagePullPolicy: IfNotPresent
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.12.yaml.template
@@ -779,8 +779,10 @@ spec:
           {{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run
+          {{- if semverCompare "<1.12.8" $semver }}
         - mountPath: /host/opt/cni/bin
           name: cni-path
+          {{- end }}
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
 {{ if .EtcdManaged }}
@@ -814,6 +816,26 @@ spec:
 {{ end }}
       hostNetwork: true
       initContainers:
+      {{- if semverCompare ">=1.12.8" $semver }}
+      - command:
+        - /install-plugin.sh
+        image: "quay.io/cilium/cilium:{{ .Version }}"
+        imagePullPolicy: IfNotPresent
+        name: install-cni-binaries
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
+      {{- end }}
       - command:
         - /init-container.sh
         env:


### PR DESCRIPTION
## [Upgrade karpenter to version 0.27.3](https://github.com/backmarket-oss/kops/pull/1/commits/3a6386553011bca90ead0b6465072d8b950a6878)
  
## [fix(cilium): install CNI plugin binary in an InitContainer](https://github.com/backmarket-oss/kops/pull/1/commits/51cfe435e9f9554f959a3fb171723d904ef0ea5e) 

Starting cilium version `1.12.8` and to reduces the potential security surface of the agent, Cilium removes the bind-mount of `/opt/cni/bin` into the template.
Instead, write the binaries once in an initContainer.

Ref:
 - https://github.com/cilium/cilium/pull/24075
 - https://github.com/kubernetes/kops/pull/15336